### PR TITLE
Add support for multiple executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-httransform
-===========
+# httransform
 
 [![Build Status](https://travis-ci.org/9seconds/httransform.svg?branch=master)](https://travis-ci.org/9seconds/httransform)
 [![CodeCov](https://codecov.io/gh/9seconds/httransform/branch/master/graph/badge.svg)](https://codecov.io/gh/9seconds/httransform)
@@ -18,7 +17,7 @@ Main features of this framework:
 2. Support of HTTPS (with CONNECT method) protocol. This library does MITM
    and provides a possibility to generate TLS certificates for the hosts
    on-the-fly.
-3. Keeps and maintans the order of header and their case (no normalization).
+3. Keeps and maintains the order of header and their case (no normalization).
 4. Support the concept of _layers_ or middlewares which process HTTP
    requests and responses
 5. Supports custom _executors_: a functions which converts HTTP request to
@@ -30,8 +29,7 @@ Please check [full
 documentation](https://godoc.org/github.com/9seconds/httransform) to get
 more details.
 
-Example
--------
+## Example
 
 Just a small example to give you a feeling how it looks like:
 
@@ -80,32 +78,32 @@ npjRm++Rs1AdvoIbZb52OqIoqoaVoxJnVchLD6t5LYXnecesAcok1e8CQEKB7ycJ
 -----END PRIVATE KEY-----`)
 
 func main() {
-	ln, err := net.Listen("tcp", "127.0.0.1:3128")
-	if err != nil {
-		panic(err)
-	}
-	opts := ServerOpts{
-		CertCA:  caCert,
-		CertKey: caPrivateKey,
-		Layers: []Layer{
-			&ProxyAuthorizationBasicLayer{
-				User:     []byte("user"),
-				Password: []byte("password"),
-				Realm:    "test",
-			},
-			&AddRemoveHeaderLayer{
-				AbsentRequestHeaders: []string{"proxy-authorization"},
-			},
-		},
-	}
-	srv, err := NewServer(opts)
-	if err != nil {
-		panic(err)
-	}
+  ln, err := net.Listen("tcp", "127.0.0.1:3128")
+  if err != nil {
+    panic(err)
+  }
+  opts := ServerOpts{
+    CertCA:  caCert,
+    CertKey: caPrivateKey,
+    Layers: []Layer{
+      &ProxyAuthorizationBasicLayer{
+        User:     []byte("user"),
+        Password: []byte("password"),
+        Realm:    "test",
+      },
+      &AddRemoveHeaderLayer{
+        AbsentRequestHeaders: []string{"proxy-authorization"},
+      },
+    },
+  }
+  srv, err := NewServer(opts)
+  if err != nil {
+    panic(err)
+  }
 
-	if err := srv.Serve(ln); err != nil {
-		panic(err)
-	}
+  if err := srv.Serve(ln); err != nil {
+    panic(err)
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Just a small example to give you a feeling how it looks like:
 package main
 
 import (
-    "net"
+  "net"
 
-    "github.com/9seconds/httransform"
+  "github.com/9seconds/httransform"
 )
 
 // These are generates examples of self-signed certificates
@@ -82,21 +82,21 @@ func main() {
   if err != nil {
     panic(err)
   }
-  opts := ServerOpts{
+  opts := httransform.ServerOpts{
     CertCA:  caCert,
     CertKey: caPrivateKey,
-    Layers: []Layer{
-      &ProxyAuthorizationBasicLayer{
+    Layers: []httransform.Layer{
+      &httransform.ProxyAuthorizationBasicLayer{
         User:     []byte("user"),
         Password: []byte("password"),
         Realm:    "test",
       },
-      &AddRemoveHeaderLayer{
+      &httransform.AddRemoveHeaderLayer{
         AbsentRequestHeaders: []string{"proxy-authorization"},
       },
     },
   }
-  srv, err := NewServer(opts)
+  srv, err := httransform.NewServer(opts)
   if err != nil {
     panic(err)
   }

--- a/executor.go
+++ b/executor.go
@@ -17,10 +17,10 @@ var executorDefaultHTTPClient = MakeStreamingClosingHTTPClient()
 type Executor func(*LayerState)
 
 // HTTPExecutor is the default executor and the simplies one you want
-// to use. It does takes HTTP request from the state and execute the
+// to use. It takes the HTTP request from the state and execute the
 // request, returning response after that.
 func HTTPExecutor(state *LayerState) {
-	ExecuteRequestTimeout(executorDefaultHTTPClient, state.Request, state.Response, DefaultHTTPTImeout)
+	ExecuteRequestTimeout(executorDefaultHTTPClient, state.Request, state.Response, DefaultHTTPTimeout)
 }
 
 // MakeProxyChainExecutor is the factory which produce executors
@@ -33,7 +33,7 @@ func MakeProxyChainExecutor(proxyURL *url.URL) (Executor, error) {
 		client := MakeStreamingClosingSOCKS5HTTPClient(proxyURL)
 
 		return func(state *LayerState) {
-			ExecuteRequestTimeout(client, state.Request, state.Response, DefaultHTTPTImeout)
+			ExecuteRequestTimeout(client, state.Request, state.Response, DefaultHTTPTimeout)
 		}, nil
 
 	case "http", "https", "":
@@ -52,7 +52,7 @@ func MakeProxyChainExecutor(proxyURL *url.URL) (Executor, error) {
 				client = httpProxyClient
 			}
 
-			ExecuteRequestTimeout(client, state.Request, state.Response, DefaultHTTPTImeout)
+			ExecuteRequestTimeout(client, state.Request, state.Response, DefaultHTTPTimeout)
 		}, nil
 	}
 

--- a/http_clients.go
+++ b/http_clients.go
@@ -25,9 +25,9 @@ const (
 	// host. Usually it is used only for proxy chains.
 	ConnectDialTimeout = 30 * time.Second
 
-	// DefaultHTTPTImeout is the timeout from starting of HTTP request to
+	// DefaultHTTPTimeout is the timeout from starting of HTTP request to
 	// getting a response.
-	DefaultHTTPTImeout = 3 * time.Minute
+	DefaultHTTPTimeout = 3 * time.Minute
 )
 
 var (

--- a/opts.go
+++ b/opts.go
@@ -86,9 +86,9 @@ type ServerOpts struct {
 	// Can be nil.
 	Layers []Layer
 
-	// Executor is an instance of the Executor used by proxy. Default is
+	// Executor is a map of instances of the Executor used by proxy. Default is
 	// HTTPExecutor.
-	Executor Executor
+	Executors map[string]Executor
 
 	// Logger is an instance of Logger used by proxy. Default is
 	// NoopLogger.
@@ -187,12 +187,14 @@ func (s *ServerOpts) GetTracerPool() *TracerPool {
 	return s.TracerPool
 }
 
-// GetExecutor returns executor to use.
-func (s *ServerOpts) GetExecutor() Executor {
-	if s.Executor == nil {
-		return HTTPExecutor
+// GetExecutor returns a map of executors.
+func (s *ServerOpts) GetExecutors() map[string]Executor {
+	if s.Executors == nil {
+		s.Executors = map[string]Executor{
+			"default": HTTPExecutor,
+		}
 	}
-	return s.Executor
+	return s.Executors
 }
 
 // GetLayers returns a list of middleware layers to use.

--- a/opts_test.go
+++ b/opts_test.go
@@ -82,9 +82,11 @@ func (suite *ServerOptsTestSuite) TestGetTracerPool() {
 }
 
 func (suite *ServerOptsTestSuite) TestGetExecutor() {
-	suite.NotNil(suite.opts.GetExecutor())
-	suite.opts.Executor = func(_ *LayerState) {}
-	suite.NotNil(suite.opts.GetExecutor())
+	suite.NotNil(suite.opts.GetExecutors())
+	suite.opts.Executors = map[string]Executor{
+		"default": func(_ *LayerState) {},
+	}
+	suite.NotNil(suite.opts.GetExecutors())
 }
 
 func (suite *ServerOptsTestSuite) TestGetLayers() {

--- a/server.go
+++ b/server.go
@@ -91,7 +91,7 @@ func (s *Server) makeHijackHandler(host string, reqID uint64, user, password []b
 
 		conf, err := s.certs.Get(host)
 		if err != nil {
-			s.logWarn("[%s] (%d): cennot generate certificate for the host %s: %s",
+			s.logWarn("[%s] (%d): cannot generate certificate for the host %s: %s",
 				conn.RemoteAddr(), reqID, host, err)
 			return
 		}
@@ -101,7 +101,7 @@ func (s *Server) makeHijackHandler(host string, reqID uint64, user, password []b
 		defer tlsConn.Close()
 
 		if err = tlsConn.Handshake(); err != nil {
-			s.logWarn("[%s] (%d): cennot finish TLS handshake: %s",
+			s.logWarn("[%s] (%d): cannot finish TLS handshake: %s",
 				conn.RemoteAddr(), reqID, err)
 			return
 		}
@@ -189,7 +189,7 @@ func (s *Server) handleRequest(ctx *fasthttp.RequestCtx, isConnect bool, user, p
 }
 
 func (s *Server) resetHeaders(headers fasthttpHeader, set *HeaderSet) {
-	// Saving and resoring of Content-Length is a hack over fasthttp.
+	// Saving and restoring of Content-Length is a hack over fasthttp.
 	// Fasthttp stores some headers in structure for faster access or other
 	// purposes and sometimes we can have a strange bugs when resulting
 	// header is not the same as resp.Header.Header() content.


### PR DESCRIPTION
Defines a default executor which will be used for all requests but
also allows the client to set a header of "X-Executor" on either
the request header on in the HTTPS case the connect header to
define a specific executor to run the request through.
e074052