### PR TITLE
Correctly abort middleware execution

### DIFF
--- a/default_layers.go
+++ b/default_layers.go
@@ -2,27 +2,17 @@ package httransform
 
 import (
 	"github.com/9seconds/httransform/v2/errors"
-	"github.com/9seconds/httransform/v2/headers"
 	"github.com/9seconds/httransform/v2/layers"
 )
 
 type layerStartHeaders struct{}
 
 func (l layerStartHeaders) OnRequest(ctx *layers.Context) error {
-	requestHeaders := headers.NewRequestHeaderWrapper(&ctx.Request().Header)
-
-	if err := ctx.RequestHeaders.Init(requestHeaders); err != nil {
-		return &errors.Error{
-			Message: "cannot read request headers",
-			Err:     err,
-		}
-	}
-
 	return nil
 }
 
 func (l layerStartHeaders) OnResponse(ctx *layers.Context, err error) error {
-	if err2 := ctx.ResponseHeaders.Sync(); err2 != nil {
+	if err2 := ctx.ResponseHeaders.Push(); err2 != nil {
 		return &errors.Error{
 			Message: "cannot sync response headers",
 			Err:     err,
@@ -35,7 +25,7 @@ func (l layerStartHeaders) OnResponse(ctx *layers.Context, err error) error {
 type layerFinishHeaders struct{}
 
 func (l layerFinishHeaders) OnRequest(ctx *layers.Context) error {
-	if err := ctx.RequestHeaders.Sync(); err != nil {
+	if err := ctx.RequestHeaders.Push(); err != nil {
 		return &errors.Error{
 			Message: "cannot sync request headers",
 			Err:     err,
@@ -46,9 +36,7 @@ func (l layerFinishHeaders) OnRequest(ctx *layers.Context) error {
 }
 
 func (l layerFinishHeaders) OnResponse(ctx *layers.Context, err error) error {
-	responseHeaders := headers.NewResponseHeaderWrapper(&ctx.Response().Header)
-
-	if err2 := ctx.ResponseHeaders.Init(responseHeaders); err2 != nil {
+	if err2 := ctx.ResponseHeaders.Pull(); err2 != nil {
 		return &errors.Error{
 			Message: "cannot read response headers",
 			Err:     err,

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -236,7 +236,7 @@ func (h *Headers) Reset(original FastHTTPHeaderWrapper) {
 // Push resets underlying fasthttp Header structure and restores it
 // based on a given header list.
 //
-// Ananlogy: git push where origin is fasthttp.Header
+// Ananlogy: git push where origin is fasthttp.Header.
 func (h *Headers) Push() error {
 	if h.original == nil {
 		return nil
@@ -303,6 +303,8 @@ func (h *Headers) pushHeaders(buf *bytes.Buffer) {
 
 // Pull reads underlying fasthttp.Header and fills a header list with
 // its contents.
+//
+// Ananlogy: git pull where origin is fasthttp.Header.
 func (h *Headers) Pull() error {
 	h.Headers = h.Headers[:0]
 

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -227,9 +227,17 @@ func (h *Headers) Append(name, value string) {
 	})
 }
 
-// Sync resets underlying fasthttp Header structure and restores it
+// Reset rebinds Headers to corresponding fasthttp data structure.
+func (h *Headers) Reset(original FastHTTPHeaderWrapper) {
+	h.Headers = h.Headers[:0]
+	h.original = original
+}
+
+// Push resets underlying fasthttp Header structure and restores it
 // based on a given header list.
-func (h *Headers) Sync() error {
+//
+// Ananlogy: git push where origin is fasthttp.Header
+func (h *Headers) Push() error {
 	if h.original == nil {
 		return nil
 	}
@@ -239,11 +247,11 @@ func (h *Headers) Sync() error {
 	buf := acquireBytesBuffer()
 	defer releaseBytesBuffer(buf)
 
-	if err := h.syncWriteFirstLine(buf); err != nil {
+	if err := h.pushFirstLine(buf); err != nil {
 		return errors.Annotate(err, "cannot get a first line", "headers_sync", 0)
 	}
 
-	h.syncWriteHeaders(buf)
+	h.pushHeaders(buf)
 
 	if err := h.original.Read(buf); err != nil {
 		return errors.Annotate(err, "cannot parse given headers", "headers_sync", 0)
@@ -258,7 +266,7 @@ func (h *Headers) Sync() error {
 	return nil
 }
 
-func (h *Headers) syncWriteFirstLine(buf *bytes.Buffer) error {
+func (h *Headers) pushFirstLine(buf *bytes.Buffer) error {
 	bytesReader := acquireBytesReader(h.original.Headers())
 	defer releaseBytesReader(bytesReader)
 
@@ -279,7 +287,7 @@ func (h *Headers) syncWriteFirstLine(buf *bytes.Buffer) error {
 	return nil
 }
 
-func (h *Headers) syncWriteHeaders(buf *bytes.Buffer) {
+func (h *Headers) pushHeaders(buf *bytes.Buffer) {
 	for i := range h.Headers {
 		buf.WriteString(h.Headers[i].name)
 		buf.WriteByte(':')
@@ -293,23 +301,16 @@ func (h *Headers) syncWriteHeaders(buf *bytes.Buffer) {
 	buf.WriteByte('\n')
 }
 
-func (h *Headers) Reset() {
+// Pull reads underlying fasthttp.Header and fills a header list with
+// its contents.
+func (h *Headers) Pull() error {
 	h.Headers = h.Headers[:0]
-	h.original = nil
-}
 
-// Init initializes a Headers datastructure based on given fasthttp
-// Header. It also binds to it so corresponding Syncs work correctly.
-func (h *Headers) Init(original FastHTTPHeaderWrapper) error {
-	h.Reset()
-
-	if original == nil {
+	if h.original == nil {
 		return nil
 	}
 
-	h.original = original
-
-	bytesReader := acquireBytesReader(original.Headers())
+	bytesReader := acquireBytesReader(h.original.Headers())
 	defer releaseBytesReader(bytesReader)
 
 	bufReader := acquireBufioReader(bytesReader)
@@ -330,15 +331,11 @@ func (h *Headers) Init(original FastHTTPHeaderWrapper) error {
 		}
 
 		if err != nil {
-			h.Reset()
-
 			return errors.Annotate(err, "cannot parse headers", "headers_init", 0)
 		}
 
 		colPosition := bytes.IndexByte(line, ':')
 		if colPosition < 0 {
-			h.Reset()
-
 			return errors.Annotate(err, "malformed header "+string(line), "headers_init", 0)
 		}
 
@@ -375,6 +372,6 @@ func AcquireHeaderSet() *Headers {
 // ReleaseHeaderSet resets a Headers and returns it back to a pool.
 // You should not use an instance of that header after this operation.
 func ReleaseHeaderSet(set *Headers) {
-	set.Reset()
+	set.Reset(nil)
 	poolHeaderSet.Put(set)
 }

--- a/headers/headers_test.go
+++ b/headers/headers_test.go
@@ -28,7 +28,13 @@ func (suite *HeadersTestSuite) SetupTest() {
 	wrapper := headers.NewRequestHeaderWrapper(suite.original)
 
 	suite.NoError(wrapper.Read(strings.NewReader(req)))
-	suite.NoError(suite.hdrs.Init(wrapper))
+
+    suite.hdrs.Reset(wrapper)
+    suite.NoError(suite.hdrs.Pull())
+}
+
+func (suite *HeadersTestSuite) TearDownTest() {
+	headers.ReleaseHeaderSet(suite.hdrs)
 }
 
 func (suite *HeadersTestSuite) TestCheckHeaders() {
@@ -213,15 +219,11 @@ func (suite *HeadersTestSuite) TestRemoveExact() {
 	suite.Len(suite.hdrs.GetAll("accept-encoding"), 1)
 }
 
-func (suite *HeadersTestSuite) TestSync() {
+func (suite *HeadersTestSuite) TestPush() {
 	suite.hdrs.Append("accept-encoding", "hello")
 
-	suite.NoError(suite.hdrs.Sync())
-    suite.Contains(string(suite.original.RawHeaders()), "accept-encoding: ")
-}
-
-func (suite *HeadersTestSuite) TearDownTest() {
-	headers.ReleaseHeaderSet(suite.hdrs)
+	suite.NoError(suite.hdrs.Push())
+	suite.Contains(string(suite.original.RawHeaders()), "accept-encoding: ")
 }
 
 func TestHeaders(t *testing.T) {

--- a/layers/ctx.go
+++ b/layers/ctx.go
@@ -203,7 +203,7 @@ func (c *Context) Init(fasthttpCtx *fasthttp.RequestCtx,
 			"cannot read request headers", "sync_headers", fasthttp.StatusBadRequest)
 	}
 
-    return nil
+	return nil
 }
 
 // Reset resets a state of the given context. It also cancels it if

--- a/layers/ctx.go
+++ b/layers/ctx.go
@@ -51,6 +51,10 @@ type Context struct {
 	//
 	// Underlying fasthttp.Request headers are going to be dropped
 	// before sending a request and repopulated from this one.
+	//
+	// If you implement a middleware, you should update this set only on
+	// OnRequest chain flow. Please do not update them in any OnResponse
+	// handler.
 	RequestHeaders headers.Headers
 
 	// ResponseHeaders is a headers of the response.
@@ -61,6 +65,10 @@ type Context struct {
 	//
 	// Underlying fasthttp.Response headers are going to be dropped before
 	// sending a response and repopulated from this one.
+	//
+	// If you implement a middleware, you should update this set only on
+	// OnResponse chain flow. Please do not update them in any OnRequest
+	// handler.
 	ResponseHeaders headers.Headers
 
 	ctxCancel   context.CancelFunc

--- a/server.go
+++ b/server.go
@@ -165,7 +165,17 @@ func (s *Server) runMain(ctx *fasthttp.RequestCtx, address, user string, request
 	ownCtx := layers.AcquireContext()
 	defer layers.ReleaseContext(ownCtx)
 
-	ownCtx.Init(ctx, address, s.eventStream, user, requestType)
+	if err := ownCtx.Init(ctx, address, s.eventStream, user, requestType); err != nil {
+		errToReturn := &errors.Error{
+			Message: "cannot execute this request",
+			Err:     err,
+		}
+
+		errToReturn.WriteTo(ctx)
+
+		return false
+	}
+
 	s.main(ownCtx)
 
 	return ownCtx.Hijacked()


### PR DESCRIPTION
There is a use case: you start to process a request but some middleware decides to abort an execution (for example, if you have some caching whatsoever). In that case middlewares can do nothing with response headers.