### PR TITLE
increase bufioReaderSize to 64K

### DIFF
--- a/headers/bufio_reader_pool.go
+++ b/headers/bufio_reader_pool.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-const bufioReaderSize = 1024 * 4
+const bufioReaderSize = 1024 * 64
 
 var poolBufioReader = sync.Pool{
 	New: func() interface{} {


### PR DESCRIPTION
Hi! Great framework!
When fetching pages with headers larger than 4K the following error is observed:
```
cannot sync response headers
```
Printnig out `err2` from [here](https://github.com/9seconds/httransform/blob/b5a1b1ca1ee9c5a5675c06050d993c5fe85559a5/default_layers.go#L15) results in the following:
```
cannot parse given headers: cannot read response headers: error when reading response headers: small read buffer. Increase ReadBufferSize. Buffer size=4096, contents: "HTTP..."
```